### PR TITLE
feat: Add post service page and functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { showLoginPage } from './pages/loginPage.js';
 import { showDashboard } from './pages/dashboardPage.js';
 import { showRegisterPage } from './pages/registerPage.js';
 import { showBrowsePage } from './pages/browsePage.js';
+import { showPostServicePage } from './pages/postServicePage.js';
 import { auth } from './services/firebase.js';
 
 const appRoot = document.getElementById('app');
@@ -74,6 +75,18 @@ function router() {
           window.location.hash = '#/login'; // Corrected
         });
       });
+      break;
+    case '#/post-service':
+      if (!currentUser) {
+        const storedUser = sessionStorage.getItem('currentUser');
+        if (storedUser) {
+          currentUser = JSON.parse(storedUser);
+        } else {
+          window.location.hash = '#/login';
+          break;
+        }
+      }
+      showPostServicePage(appRoot);
       break;
     default:
       // Fallback logic based on current user status

--- a/src/pages/dashboardPage.js
+++ b/src/pages/dashboardPage.js
@@ -9,6 +9,9 @@ export function showDashboard(rootElement, user, onLogout) {
       <button id="buscar-servicios-btn" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded ml-2">
         Buscar Servicios
       </button>
+      <button id="post-service-btn" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded ml-2">
+        Publicar Servicio
+      </button>
     </div>
   `;
 
@@ -30,6 +33,13 @@ export function showDashboard(rootElement, user, onLogout) {
   if (buscarServiciosBtn) {
     buscarServiciosBtn.addEventListener("click", () => {
       window.location.hash = '#/browse';
+    });
+  }
+
+  const postServiceBtn = document.getElementById("post-service-btn");
+  if (postServiceBtn) {
+    postServiceBtn.addEventListener("click", () => {
+      window.location.hash = '#/post-service';
     });
   }
 }

--- a/src/pages/postServicePage.js
+++ b/src/pages/postServicePage.js
@@ -1,0 +1,70 @@
+export function showPostServicePage(rootElement) {
+  rootElement.innerHTML = `
+    <div class="p-4">
+      <h2 class="text-2xl font-semibold mb-4">Publicar Nuevo Servicio</h2>
+      <form id="post-service-form">
+        <div class="mb-4">
+          <label for="service-title" class="block text-gray-700 text-sm font-bold mb-2">Título del Servicio:</label>
+          <input type="text" id="service-title" name="service-title" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>
+        </div>
+
+        <div class="mb-4">
+          <label for="service-description" class="block text-gray-700 text-sm font-bold mb-2">Descripción:</label>
+          <textarea id="service-description" name="service-description" rows="4" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline" required></textarea>
+        </div>
+
+        <div class="mb-4">
+          <label for="service-category" class="block text-gray-700 text-sm font-bold mb-2">Categoría:</label>
+          <select id="service-category" name="service-category" class="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>
+            <option value="Plomeria">Plomería</option>
+            <option value="Carpinteria">Carpintería</option>
+            <option value="Electricista">Electricista</option>
+            <option value="Programacion">Programación</option>
+            <option value="Clases particulares">Clases particulares</option>
+            <option value="Otros">Otros</option>
+          </select>
+        </div>
+
+        <div class="mb-6">
+          <label for="service-price" class="block text-gray-700 text-sm font-bold mb-2">Precio estimado (MXN):</label>
+          <input type="number" id="service-price" name="service-price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <button type="submit" id="publish-service-btn" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+            Publicar
+          </button>
+          <button type="button" id="back-to-dashboard-btn" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+            Volver al Dashboard
+          </button>
+        </div>
+      </form>
+    </div>
+  `;
+
+  const form = rootElement.querySelector('#post-service-form');
+  const backToDashboardBtn = rootElement.querySelector('#back-to-dashboard-btn');
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const title = rootElement.querySelector('#service-title').value;
+    const description = rootElement.querySelector('#service-description').value;
+    const category = rootElement.querySelector('#service-category').value;
+    const price = rootElement.querySelector('#service-price').value;
+
+    const serviceData = {
+      title,
+      description,
+      category,
+      price,
+    };
+
+    console.log('Service Data:', serviceData);
+    alert('Servicio publicado con éxito');
+    window.location.hash = '#/dashboard';
+  });
+
+  backToDashboardBtn.addEventListener('click', () => {
+    window.location.hash = '#/dashboard';
+  });
+}


### PR DESCRIPTION
Implemented a new page for you to post services.

Key changes:
- Created `src/pages/postServicePage.js` which includes a form with fields for service title, description, category, and estimated price.
- Form submission logs data to the console, displays a success alert, and navigates to the dashboard.
- Added a 'Volver al Dashboard' button for navigation.
- Updated `src/index.js` to include a route `#/post-service` for the new page, with a check for your authentication.
- Modified `src/pages/dashboardPage.js` to add a 'Publicar Servicio' button that navigates to `#/post-service`.